### PR TITLE
Fix import path for Supabase script

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ npm run dev
 - `npm run build`: Construye la aplicación para producción
 - `npm run preview`: Previsualiza la build de producción
 - `npm run lint`: Ejecuta el linter
+- `node --loader ts-node/esm check-supabase-connection.js`: Verifica la conexión con Supabase
 
 ## 🔐 Autenticación
 

--- a/check-supabase-connection.js
+++ b/check-supabase-connection.js
@@ -1,5 +1,6 @@
 // Script para verificar la conexión con Supabase
-import { supabase } from './src/lib/supabase.js';
+// Import the TypeScript implementation directly
+import { supabase } from './src/lib/supabase.ts';
 
 async function checkSupabaseConnection() {
   console.log('🔍 Verificando conexión con Supabase...\n');


### PR DESCRIPTION
## Summary
- import Supabase helper using the `.ts` source
- mention `ts-node` loader in README so the script can run

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `node check-supabase-connection.js` *(fails: Unknown file extension `.ts`)*

------
https://chatgpt.com/codex/tasks/task_e_684f06b8119c832a8d0ab4a67e73718c