### PR TITLE
Add validateAssignment tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest"
   },
   "dependencies": {
     "@dnd-kit/core": "^6.1.0",
@@ -31,6 +32,7 @@
     "tailwindcss": "^3.4.1",
     "typescript": "^5.5.3",
     "typescript-eslint": "^8.3.0",
-    "vite": "^5.4.2"
+    "vite": "^5.4.2",
+    "vitest": "^1.0.0"
   }
 }

--- a/src/utils/validateAssignment.ts
+++ b/src/utils/validateAssignment.ts
@@ -1,0 +1,29 @@
+export interface GroupInfo {
+  maxCapacity: number;
+  currentCapacity: number;
+  students: string[];
+}
+
+/**
+ * Validates a batch of student assignments.
+ * @param studentIds IDs of students to assign.
+ * @param group Current group information.
+ * @returns Error message if validation fails, otherwise null.
+ */
+export function validateAssignment(studentIds: string[], group: GroupInfo): string | null {
+  if (studentIds.length === 0) {
+    return 'Debe seleccionar al menos un estudiante';
+  }
+
+  const remainingCapacity = group.maxCapacity - group.currentCapacity;
+  if (studentIds.length > remainingCapacity) {
+    return `Solo quedan ${remainingCapacity} espacios disponibles en el grupo`;
+  }
+
+  const alreadyAssigned = studentIds.filter(id => group.students.includes(id));
+  if (alreadyAssigned.length > 0) {
+    return 'Algunos estudiantes ya están asignados a este grupo';
+  }
+
+  return null;
+}

--- a/tests/validateAssignment.test.ts
+++ b/tests/validateAssignment.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'vitest';
+import { validateAssignment, GroupInfo } from '../src/utils/validateAssignment';
+
+describe('validateAssignment', () => {
+  const baseGroup: GroupInfo = {
+    maxCapacity: 3,
+    currentCapacity: 1,
+    students: ['a']
+  };
+
+  it('returns error when no students selected', () => {
+    const result = validateAssignment([], baseGroup);
+    expect(result).toBe('Debe seleccionar al menos un estudiante');
+  });
+
+  it('returns error when capacity exceeded', () => {
+    const result = validateAssignment(['b', 'c', 'd'], baseGroup);
+    expect(result).toBe('Solo quedan 2 espacios disponibles en el grupo');
+  });
+
+  it('returns error when duplicate assignments', () => {
+    const result = validateAssignment(['a', 'b'], baseGroup);
+    expect(result).toBe('Algunos estudiantes ya están asignados a este grupo');
+  });
+
+  it('returns null when assignments are valid', () => {
+    const result = validateAssignment(['b'], baseGroup);
+    expect(result).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- implement `validateAssignment` utility
- add Vitest test covering validation edge cases
- expose new `test` script

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f06bc9d74832aaa06aac57261e6a6