### PR TITLE
Fix StatCard icon type import

### DIFF
--- a/src/components/UI/StatCard.tsx
+++ b/src/components/UI/StatCard.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { DivideIcon as LucideIcon } from 'lucide-react';
+import type { LucideIcon } from 'lucide-react';
 
 interface StatCardProps {
   title: string;


### PR DESCRIPTION
## Summary
- clean up StatCard import

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684f123cef78832a8ef57e1ff3105600