### PR TITLE
Fix chart stretching in reports page

### DIFF
--- a/src/pages/admin/ReportsAnalysis.tsx
+++ b/src/pages/admin/ReportsAnalysis.tsx
@@ -313,23 +313,23 @@ export default function ReportsAnalysis() {
         <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
           <div className="bg-white rounded-xl shadow-sm border p-4">
             <h3 className="mb-2 font-semibold">Asistencia por Grupo</h3>
-            <Line data={attendanceChart} height={200} options={{ maintainAspectRatio: false }} />
+            <Line data={attendanceChart} options={{ maintainAspectRatio: false }} style={{ height: '200px' }} />
           </div>
           <div className="bg-white rounded-xl shadow-sm border p-4">
             <h3 className="mb-2 font-semibold">Notas Medias por Asignatura</h3>
-            <Bar data={gradesChart} height={200} options={{ maintainAspectRatio: false }} />
+            <Bar data={gradesChart} options={{ maintainAspectRatio: false }} style={{ height: '200px' }} />
           </div>
           <div className="bg-white rounded-xl shadow-sm border p-4">
             <h3 className="mb-2 font-semibold">Distribución de Usuarios</h3>
-            <Pie data={userPie} height={200} options={{ maintainAspectRatio: false }} />
+            <Pie data={userPie} options={{ maintainAspectRatio: false }} style={{ height: '200px' }} />
           </div>
           <div className="bg-white rounded-xl shadow-sm border p-4">
             <h3 className="mb-2 font-semibold">Progresión Académica</h3>
-            <Line data={progressChart} height={200} options={{ maintainAspectRatio: false }} />
+            <Line data={progressChart} options={{ maintainAspectRatio: false }} style={{ height: '200px' }} />
           </div>
           <div className="bg-white rounded-xl shadow-sm border p-4 lg:col-span-2">
             <h3 className="mb-2 font-semibold">Resumen de Actividad</h3>
-            <Bar data={activityChart} height={200} options={{ maintainAspectRatio: false }} />
+            <Bar data={activityChart} options={{ maintainAspectRatio: false }} style={{ height: '200px' }} />
           </div>
         </div>
 


### PR DESCRIPTION
## Summary
- fix charts by setting canvas height via style so Chart.js doesn't stretch vertically

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684f21670d00832a8a372a9e74ab53d8