### PR TITLE
Fix graph panels from stretching infinitely

### DIFF
--- a/src/pages/admin/ReportsAnalysis.tsx
+++ b/src/pages/admin/ReportsAnalysis.tsx
@@ -313,23 +313,23 @@ export default function ReportsAnalysis() {
         <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
           <div className="bg-white rounded-xl shadow-sm border p-4">
             <h3 className="mb-2 font-semibold">Asistencia por Grupo</h3>
-            <Line data={attendanceChart} options={{ maintainAspectRatio: false }} style={{ height: '200px' }} />
+            <Line data={attendanceChart} options={{ maintainAspectRatio: false }} height={200} />
           </div>
           <div className="bg-white rounded-xl shadow-sm border p-4">
             <h3 className="mb-2 font-semibold">Notas Medias por Asignatura</h3>
-            <Bar data={gradesChart} options={{ maintainAspectRatio: false }} style={{ height: '200px' }} />
+            <Bar data={gradesChart} options={{ maintainAspectRatio: false }} height={200} />
           </div>
           <div className="bg-white rounded-xl shadow-sm border p-4">
             <h3 className="mb-2 font-semibold">Distribución de Usuarios</h3>
-            <Pie data={userPie} options={{ maintainAspectRatio: false }} style={{ height: '200px' }} />
+            <Pie data={userPie} options={{ maintainAspectRatio: false }} height={200} />
           </div>
           <div className="bg-white rounded-xl shadow-sm border p-4">
             <h3 className="mb-2 font-semibold">Progresión Académica</h3>
-            <Line data={progressChart} options={{ maintainAspectRatio: false }} style={{ height: '200px' }} />
+            <Line data={progressChart} options={{ maintainAspectRatio: false }} height={200} />
           </div>
           <div className="bg-white rounded-xl shadow-sm border p-4 lg:col-span-2">
             <h3 className="mb-2 font-semibold">Resumen de Actividad</h3>
-            <Bar data={activityChart} options={{ maintainAspectRatio: false }} style={{ height: '200px' }} />
+            <Bar data={activityChart} options={{ maintainAspectRatio: false }} height={200} />
           </div>
         </div>
 


### PR DESCRIPTION
## Summary
- adjust height property for all charts in `ReportsAnalysis`

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_684f2cee7ad0832a8e480b626072b74f