### PR TITLE
Add env fallbacks for Supabase client

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,11 @@ VITE_SUPABASE_URL=tu_supabase_url
 VITE_SUPABASE_ANON_KEY=tu_supabase_anon_key
 ```
 
+Si ejecutas scripts o pruebas fuera del entorno de Vite, la librería intentará
+leer las mismas variables desde `process.env`. Asegúrate de definir
+`VITE_SUPABASE_URL` y `VITE_SUPABASE_ANON_KEY` en tu entorno de ejecución si
+`import.meta.env` no está disponible.
+
 5. Ejecuta las migraciones de la base de datos en Supabase
 
 6. Inicia el servidor de desarrollo:

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -1,7 +1,10 @@
 import { createClient } from '@supabase/supabase-js';
 
-const supabaseUrl = import.meta.env.VITE_SUPABASE_URL;
-const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY;
+// Prefer Vite environment variables but fall back to Node process env
+const viteEnv = typeof import.meta !== 'undefined' ? import.meta.env : undefined;
+const supabaseUrl = viteEnv?.VITE_SUPABASE_URL ?? process.env.VITE_SUPABASE_URL;
+const supabaseAnonKey =
+  viteEnv?.VITE_SUPABASE_ANON_KEY ?? process.env.VITE_SUPABASE_ANON_KEY;
 
 // Create a mock client for demo purposes when environment variables are missing
 const createMockClient = () => {


### PR DESCRIPTION
## Summary
- support `process.env` fallbacks when `import.meta.env` isn't defined for Supabase client
- document environment variable fallback behavior

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684f49b0df2c832a97f47ca206e5e8b0