### PR TITLE
Add grades module

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,10 +13,12 @@ import CursoMateriasPage from './components/CursosMaterias/CursoMateriasPage';
 import CursosMateriasPage from './features/cursosMaterias/CursosMateriasPage';
 import TeacherDashboard from './pages/teacher/TeacherDashboard';
 import TeacherClasses from './pages/teacher/TeacherClasses';
+import TeacherGrades from './pages/teacher/TeacherGrades';
 import StudentDashboard from './pages/student/StudentDashboard';
 import ParentDashboard from './pages/parent/ParentDashboard';
 import ReportsAnalysis from './pages/admin/ReportsAnalysis';
 import SystemSettings from './pages/admin/SystemSettings';
+import GradesManagement from './pages/admin/GradesManagement';
 
 function ProtectedRoute({ children, allowedRoles }: { children: React.ReactNode; allowedRoles: string[] }) {
   const { user, isLoading } = useAuth();
@@ -68,6 +70,7 @@ function AppRoutes() {
         <Route path="courses" element={<CursoMateriasPage />} />
         <Route path="cursos-materias" element={<CursosMateriasPage />} />
         <Route path="reports" element={<ReportsAnalysis />} />
+        <Route path="grades-management" element={<GradesManagement />} />
         <Route path="settings" element={<SystemSettings />} />
       </Route>
 
@@ -82,7 +85,7 @@ function AppRoutes() {
       >
         <Route index element={<TeacherDashboard />} />
         <Route path="classes" element={<TeacherClasses />} />
-        <Route path="grades" element={<div className="p-6">Calificaciones y Asistencia (Próximamente)</div>} />
+        <Route path="grades" element={<TeacherGrades />} />
         <Route path="assignments" element={<div className="p-6">Tareas (Próximamente)</div>} />
         <Route path="resources" element={<div className="p-6">Recursos Educativos (Próximamente)</div>} />
         <Route path="messages" element={<div className="p-6">Mensajes (Próximamente)</div>} />

--- a/src/components/Layout/Sidebar.tsx
+++ b/src/components/Layout/Sidebar.tsx
@@ -27,6 +27,7 @@ const navigationItems = {
     { icon: LayoutDashboard, label: 'Panel Principal', path: '/admin' },
     { icon: Users, label: 'Gestión de Usuarios', path: '/admin/users' },
     { icon: Layers, label: 'Asignaciones', path: '/admin/cursos-materias' },
+    { icon: ClipboardList, label: 'Gestión de Calificaciones', path: '/admin/grades-management' },
     { icon: TrendingUp, label: 'Reportes y Análisis', path: '/admin/reports' },
     { icon: Settings, label: 'Configuración', path: '/admin/settings' },
   ],

--- a/src/context/GradesContext.tsx
+++ b/src/context/GradesContext.tsx
@@ -1,0 +1,178 @@
+import React, { createContext, useContext, useEffect, useState } from 'react';
+import { supabase } from '../lib/supabase';
+
+export interface Trimester {
+  id: string;
+  name: string;
+  courseId: string;
+  order: number;
+}
+
+export interface GradeFolder {
+  id: string;
+  trimesterId: string;
+  subjectId: string;
+  name: string;
+  description?: string;
+  createdAt: string;
+}
+
+export interface GradeColumn {
+  id: string;
+  folderId: string;
+  name: string;
+  type: 'numeric' | 'text';
+  date: string;
+}
+
+export interface GradeValue {
+  id: string;
+  columnId: string;
+  studentId: string;
+  value: string;
+  notes?: string;
+}
+
+interface GradesContextType {
+  trimesters: Trimester[];
+  folders: GradeFolder[];
+  columns: GradeColumn[];
+  values: GradeValue[];
+  addTrimester: (name: string) => Promise<void>;
+  addFolder: (trimesterId: string, name: string) => Promise<string>;
+  duplicateFolder: (folderId: string) => Promise<void>;
+  addColumn: (folderId: string, name: string) => Promise<void>;
+  updateValue: (columnId: string, studentId: string, value: string) => Promise<void>;
+  loading: boolean;
+}
+
+const GradesContext = createContext<GradesContextType | undefined>(undefined);
+
+const isMockMode = (supabase as any).isMock === true;
+
+// Demo data
+const DEMO_TRIMESTERS: Trimester[] = [
+  { id: 't1', name: '1º Trimestre', courseId: 'course-1', order: 1 },
+  { id: 't2', name: '2º Trimestre', courseId: 'course-1', order: 2 },
+  { id: 't3', name: '3º Trimestre', courseId: 'course-1', order: 3 }
+];
+
+const DEMO_FOLDERS: GradeFolder[] = [
+  { id: 'f1', trimesterId: 't1', subjectId: 'math', name: 'Exámenes', createdAt: new Date().toISOString() }
+];
+
+const DEMO_COLUMNS: GradeColumn[] = [
+  { id: 'c1', folderId: 'f1', name: 'Examen 1', type: 'numeric', date: new Date().toISOString() }
+];
+
+let demoValues: GradeValue[] = [];
+
+export function GradesProvider({ children }: { children: React.ReactNode }) {
+  const [trimesters, setTrimesters] = useState<Trimester[]>(DEMO_TRIMESTERS);
+  const [folders, setFolders] = useState<GradeFolder[]>(DEMO_FOLDERS);
+  const [columns, setColumns] = useState<GradeColumn[]>(DEMO_COLUMNS);
+  const [values, setValues] = useState<GradeValue[]>(demoValues);
+  const [loading, setLoading] = useState(false);
+
+
+  useEffect(() => {
+    if (!isMockMode) {
+      // Load data from Supabase - simplified
+      // For brevity we use demo data if fetching fails
+      const load = async () => {
+        try {
+          setLoading(true);
+          const { data: tri } = await supabase.from('trimesters').select('*');
+          const { data: fol } = await supabase.from('grade_folders').select('*');
+          const { data: col } = await supabase.from('grade_columns').select('*');
+          const { data: val } = await supabase.from('grade_values').select('*');
+          if (tri) setTrimesters(tri as any);
+          if (fol) setFolders(fol as any);
+          if (col) setColumns(col as any);
+          if (val) setValues(val as any);
+        } catch (err) {
+          console.warn('Supabase unavailable, using demo data');
+          setTrimesters(DEMO_TRIMESTERS);
+          setFolders(DEMO_FOLDERS);
+          setColumns(DEMO_COLUMNS);
+        } finally {
+          setLoading(false);
+        }
+      };
+      load();
+    }
+  }, []);
+
+  const addTrimester = async (name: string) => {
+    const newTri: Trimester = { id: `tri-${Date.now()}`, name, courseId: 'course-1', order: trimesters.length + 1 };
+    if (isMockMode) {
+      setTrimesters(prev => [...prev, newTri]);
+      return;
+    }
+    await supabase.from('trimesters').insert(newTri);
+    setTrimesters(prev => [...prev, newTri]);
+  };
+
+  const addFolder = async (trimesterId: string, name: string) => {
+    const newFolder: GradeFolder = { id: `folder-${Date.now()}`, trimesterId, subjectId: 'math', name, createdAt: new Date().toISOString() };
+    if (isMockMode) {
+      setFolders(prev => [...prev, newFolder]);
+      return newFolder.id;
+    }
+    await supabase.from('grade_folders').insert(newFolder);
+    setFolders(prev => [...prev, newFolder]);
+    return newFolder.id;
+  };
+
+  const duplicateFolder = async (folderId: string) => {
+    const orig = folders.find(f => f.id === folderId);
+    if (!orig) return;
+    const newFolderId = `folder-${Date.now()}`;
+    const newFolder = { ...orig, id: newFolderId, name: `${orig.name} (copia)` };
+    if (isMockMode) {
+      setFolders(prev => [...prev, newFolder]);
+      const cols = columns.filter(c => c.folderId === folderId).map(c => ({ ...c, id: `col-${Date.now()}-${Math.random()}`, folderId: newFolderId }));
+      setColumns(prev => [...prev, ...cols]);
+      const vals = values.filter(v => cols.some(c => c.id === v.columnId)).map(v => ({ ...v, id: `val-${Date.now()}-${Math.random()}`, columnId: v.columnId }));
+      setValues(prev => [...prev, ...vals]);
+      return;
+    }
+    await supabase.from('grade_folders').insert(newFolder);
+  };
+
+  const addColumn = async (folderId: string, name: string) => {
+    const newCol: GradeColumn = { id: `col-${Date.now()}`, folderId, name, type: 'numeric', date: new Date().toISOString() };
+    if (isMockMode) {
+      setColumns(prev => [...prev, newCol]);
+      return;
+    }
+    await supabase.from('grade_columns').insert(newCol);
+    setColumns(prev => [...prev, newCol]);
+  };
+
+  const updateValue = async (columnId: string, studentId: string, value: string) => {
+    let val = values.find(v => v.columnId === columnId && v.studentId === studentId);
+    if (!val) {
+      val = { id: `val-${Date.now()}`, columnId, studentId, value };
+      setValues(prev => [...prev, val!]);
+      if (!isMockMode) await supabase.from('grade_values').insert(val);
+      return;
+    }
+    val.value = value;
+    setValues(prev => prev.map(v => (v.id === val!.id ? val! : v)));
+    if (!isMockMode) await supabase.from('grade_values').update({ value }).eq('id', val.id);
+  };
+
+  return (
+    <GradesContext.Provider value={{ trimesters, folders, columns, values, addTrimester, addFolder, duplicateFolder, addColumn, updateValue, loading }}>
+      {children}
+    </GradesContext.Provider>
+  );
+}
+
+export function useGrades() {
+  const ctx = useContext(GradesContext);
+  if (!ctx) throw new Error('useGrades must be used within GradesProvider');
+  return ctx;
+}
+

--- a/src/pages/admin/GradesManagement.tsx
+++ b/src/pages/admin/GradesManagement.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { useGrades, GradesProvider } from '../../context/GradesContext';
+
+function GradesSummary() {
+  const { trimesters, folders, columns } = useGrades();
+
+  return (
+    <div className="space-y-4">
+      <h1 className="text-2xl font-bold text-gray-900">Gestión de Calificaciones</h1>
+      <div className="bg-white p-4 rounded-xl border border-gray-200">
+        <h2 className="font-semibold mb-2">Resumen</h2>
+        <p>{trimesters.length} trimestres</p>
+        <p>{folders.length} carpetas</p>
+        <p>{columns.length} columnas de calificaciones</p>
+      </div>
+    </div>
+  );
+}
+
+export default function GradesManagement() {
+  return (
+    <GradesProvider>
+      <GradesSummary />
+    </GradesProvider>
+  );
+}
+

--- a/src/pages/teacher/TeacherGrades.tsx
+++ b/src/pages/teacher/TeacherGrades.tsx
@@ -1,0 +1,138 @@
+import React, { useMemo, useState } from 'react';
+import { Plus, Copy } from 'lucide-react';
+import { useGrades, GradesProvider } from '../../context/GradesContext';
+import { useUsers } from '../../context/UsersContext';
+
+function GradesTable({ folderId }: { folderId: string }) {
+  const { columns, values, addColumn, updateValue } = useGrades();
+  const { users } = useUsers();
+  const students = useMemo(() => users.filter(u => u.role === 'student'), [users]);
+  const folderColumns = columns.filter(c => c.folderId === folderId);
+
+  const handleAddColumn = async () => {
+    const name = window.prompt('Nombre de la calificación');
+    if (name) await addColumn(folderId, name);
+  };
+
+  const getValue = (colId: string, studentId: string) => {
+    const val = values.find(v => v.columnId === colId && v.studentId === studentId);
+    return val ? val.value : '';
+  };
+
+  const handleChange = (colId: string, studentId: string, value: string) => {
+    updateValue(colId, studentId, value);
+  };
+
+  return (
+    <div className="space-y-2">
+      <div className="flex justify-end">
+        <button onClick={handleAddColumn} className="px-3 py-1 text-sm bg-emerald-600 text-white rounded-lg flex items-center gap-1">
+          <Plus className="w-4 h-4" /> Añadir columna
+        </button>
+      </div>
+      <div className="overflow-auto">
+        <table className="min-w-full bg-white border border-gray-200 text-sm">
+          <thead>
+            <tr>
+              <th className="px-2 py-1 border">Alumno</th>
+              {folderColumns.map(col => (
+                <th key={col.id} className="px-2 py-1 border text-left">{col.name}</th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {students.map(st => (
+              <tr key={st.id} className="hover:bg-gray-50">
+                <td className="px-2 py-1 border font-medium">{st.name}</td>
+                {folderColumns.map(col => (
+                  <td key={col.id} className="px-2 py-1 border">
+                    <input
+                      className="w-20 border rounded px-1 text-sm"
+                      value={getValue(col.id, st.id)}
+                      onChange={e => handleChange(col.id, st.id, e.target.value)}
+                    />
+                  </td>
+                ))}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}
+
+function GradesContent() {
+  const { trimesters, folders, addTrimester, addFolder, duplicateFolder } = useGrades();
+  const [activeTrimester, setActiveTrimester] = useState(trimesters[0]?.id);
+  const [activeFolder, setActiveFolder] = useState<string | null>(null);
+
+  const handleAddTrimester = async () => {
+    const name = window.prompt('Nombre del trimestre');
+    if (name) await addTrimester(name);
+  };
+
+  const handleAddFolder = async () => {
+    if (!activeTrimester) return;
+    const name = window.prompt('Nombre de la carpeta');
+    if (name) {
+      const id = await addFolder(activeTrimester, name);
+      setActiveFolder(id);
+    }
+  };
+
+  const foldersByTrim = folders.filter(f => f.trimesterId === activeTrimester);
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center gap-2">
+        {trimesters.map(t => (
+          <button
+            key={t.id}
+            onClick={() => { setActiveTrimester(t.id); setActiveFolder(null); }}
+            className={`px-4 py-2 rounded-lg text-sm ${activeTrimester === t.id ? 'bg-emerald-600 text-white' : 'bg-gray-200'}`}
+          >
+            {t.name}
+          </button>
+        ))}
+        <button onClick={handleAddTrimester} className="px-2 py-2 rounded-lg bg-blue-500 text-white text-sm">
+          <Plus className="w-4 h-4" />
+        </button>
+      </div>
+
+      <div className="flex gap-4">
+        <div className="w-48 space-y-2">
+          <div className="flex justify-between items-center">
+            <h3 className="font-semibold">Carpetas</h3>
+            <button onClick={handleAddFolder} className="text-emerald-600"><Plus className="w-4 h-4" /></button>
+          </div>
+          <ul className="space-y-1">
+            {foldersByTrim.map(f => (
+              <li key={f.id}>
+                <button
+                  onClick={() => setActiveFolder(f.id)}
+                  className={`w-full text-left px-2 py-1 rounded ${activeFolder === f.id ? 'bg-emerald-100' : 'bg-gray-100'}`}
+                >
+                  {f.name}
+                </button>
+                <button onClick={() => duplicateFolder(f.id)} className="ml-1 text-xs text-gray-500"><Copy className="w-3 h-3" /></button>
+              </li>
+            ))}
+          </ul>
+        </div>
+        <div className="flex-1">
+          {activeFolder ? <GradesTable folderId={activeFolder} /> : <p className="text-gray-600">Selecciona una carpeta.</p>}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default function TeacherGrades() {
+  return (
+    <GradesProvider>
+      <GradesContent />
+    </GradesProvider>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add `GradesContext` with mock/demo support for Supabase
- implement teacher grades page with simple spreadsheet-style editing
- implement admin grades management summary page
- link new pages into sidebar and routes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684f55d342d4832ab63f5a772a698625